### PR TITLE
Expand patron identifier config options

### DIFF
--- a/iNCIPit-example.ini
+++ b/iNCIPit-example.ini
@@ -10,11 +10,16 @@ password = EXAMPLE
 [behavior]
 #no_item_agency_holds = no
 #omit_patron_email    = no
-#patron_id_as_identifier = no
+# current patron_identifier options are:
+# barcode - patron barcode (default)
+# id - database id
+# future:
+# ident - patron ident field
+#patron_identifier    = id
 
 [checkout]
 # This needs to be either a barcode or a patron id,
-# depending on the setting of patron_id_as_identifier
+# depending on the setting of patron_identifier
 institutional_patron = 1234567
 
 [copy]

--- a/iNCIPit.cgi
+++ b/iNCIPit.cgi
@@ -74,12 +74,17 @@ if (-e $conffile) {
 }
 
 # Set some variables from config (or defaults)
-my $patron_id_type;
 
-if ($conf->{behavior}->{patron_id_as_identifier} =~ m/^yes$/i) {
-    $patron_id_type = "id";
-} else {
-    $patron_id_type = "barcode";
+# Default patron_identifier type is barcode
+my $patron_id_type = "barcode";
+
+# if the config specifies a patron_identifier type
+if (my $conf_patron_id_type = $conf->{behavior}->{patron_identifier}) {
+    # and that patron_identifier type is known
+    if ($conf_patron_id_type =~ m/(barcode|id)/) {
+        # override the default with the value from the config
+        $patron_id_type = $conf_patron_id_type;
+    }
 }
 
 # reject non-https access unless configured otherwise


### PR DESCRIPTION
Remove the patron_id_as_identifier yes/no configuration option and
replace it with "patron_identifier" which accepts the following:
- barcode - patron barcode (the default)
- id - patron database id

In the near future, we expect to have an additional option:
- ident - patron's ident value

This future third option will require additional work for retrieving
patrons via their ident value, etc.

Signed-off-by: Jeff Godin jgodin@tadl.org
