### PR TITLE
Handle invalid xml

### DIFF
--- a/iNCIPit.cgi
+++ b/iNCIPit.cgi
@@ -39,6 +39,7 @@
 use warnings;
 use strict;
 use XML::LibXML;
+use XML::LibXML::ErrNo;
 use CGI;
 use HTML::Entities;
 use CGI::Carp;


### PR DESCRIPTION
Two commits to improve our reaction when invalid XML is encountered in an incoming NCIP message.

Includes mitigation for something we've seem twice in testing / production with INN-REACH: a raw Control-D character.
