### PR TITLE
xml escaping fixes

### DIFF
--- a/iNCIPit.cgi
+++ b/iNCIPit.cgi
@@ -871,9 +871,9 @@ sub item_request {
 
     # Avoid generating invalid XML responses by encoding title/author/callnumber
     # TODO: Move away from heredocs for generating XML
-	$title  = HTML::Entities::encode($title);
-	$author = HTML::Entities::encode($author);
-	$callnumber = HTML::Entities::encode($callnumber);
+	$title      = _naive_encode_xml($title);
+	$author     = _naive_encode_xml($author);
+	$callnumber = _naive_encode_xml($callnumber);
 
     my $hd = <<ITEMREQ;
 Content-type: text/xml
@@ -1789,4 +1789,14 @@ sub flesh_user {
         [ 'card', 'cards', 'standing_penalties', 'home_ou', 'profile' ] )
       ->gather(1);
     return $response;
+}
+
+sub _naive_encode_xml {
+    my $val = shift;
+
+    $val =~ s/&/&amp;/g;
+    $val =~ s/</&lt;/g;
+    $val =~ s/>/&gt;/g;
+
+    return $val;
 }

--- a/iNCIPit.cgi
+++ b/iNCIPit.cgi
@@ -869,10 +869,11 @@ sub item_request {
         }
     }
 
-    # Avoid generating invalid XML responses by encoding title/author
+    # Avoid generating invalid XML responses by encoding title/author/callnumber
     # TODO: Move away from heredocs for generating XML
 	$title  = HTML::Entities::encode($title);
 	$author = HTML::Entities::encode($author);
+	$callnumber = HTML::Entities::encode($callnumber);
 
     my $hd = <<ITEMREQ;
 Content-type: text/xml


### PR DESCRIPTION
In addition to title and author, also attempt to escape call number values in ItemRequestedResponse messages.

Also, don't use HTML::Entities::encode as that can introduce HTML entities which are not valid built-in XML entities.
