### PR TITLE
Fix due date field in renew_item()

### DIFF
--- a/iNCIPit.cgi
+++ b/iNCIPit.cgi
@@ -337,7 +337,7 @@ sub renew_item {
 
     my $pid = $doc->findvalue('/NCIPMessage/RenewItem/UniqueUserId/UserIdentifierValue');
     my $unique_item_id = $doc->findvalue('/NCIPMessage/RenewItem/UniqueItemId/ItemIdentifierValue');
-    my $due_date = $doc->findvalue('/NCIPMessage/RenewItem/DateDue');
+    my $due_date = $doc->findvalue('/NCIPMessage/RenewItem/DesiredDateDue');
 
     # we are using the UniqueItemId value as a barcode here
     my $r = renewal( $unique_item_id, $due_date );


### PR DESCRIPTION
The RenewItem message has a 'DesiredDueDate' field, not just 'DueDate'

Signed-off-by: Dan Wells dbw2@calvin.edu
