### PR TITLE
Patron id or barcode handling for ItemRequested

### DIFF
--- a/iNCIPit.cgi
+++ b/iNCIPit.cgi
@@ -842,7 +842,12 @@ sub item_request {
 
     # TODO: should we use the VisibleID for item agency variation of this method call
 
-    my $pid = $doc->findvalue('/NCIPMessage/ItemRequested/UniqueUserId/UserIdentifierValue');
+    if ($patron_id_type == "barcode") {
+        my $pid = $doc->findvalue('/NCIPMessage/ItemRequested/UserOptionalFields/VisibleUserId/VisibleUserIdentifier');
+        $pid    = user_id_from_barcode($pid);
+    else {
+        my $pid = $doc->findvalue('/NCIPMessage/ItemRequested/UniqueUserId/UserIdentifierValue');
+    }
     my $barcode = $doc->findvalue('/NCIPMessage/ItemRequested/UniqueItemId/ItemIdentifierValue');
     my $author = $doc->findvalue('/NCIPMessage/ItemRequested/ItemOptionalFields/BibliographicDescription/Author');
     my $title = $doc->findvalue('/NCIPMessage/ItemRequested/ItemOptionalFields/BibliographicDescription/Title');


### PR DESCRIPTION
This is the second of two issues trying to fully align a fork with this main repo. ItemRequested messages send the patron barcode in VisibleUserIdentifier. To place the hold the patron id then needs to be retrieved using the barcode. Sorry, I don't have direct access for testing any longer so this is a proposed, but untested solution (well the conditional aspect is untested, and whether or not this is appropriate for handling the general case).
